### PR TITLE
Edg 33 certification info object to string/array of string

### DIFF
--- a/core/src/main/resources/2.0/EPCIS/JSON/Capture/Documents/AggregationEvent_all_possible_fields.json
+++ b/core/src/main/resources/2.0/EPCIS/JSON/Capture/Documents/AggregationEvent_all_possible_fields.json
@@ -24,13 +24,7 @@
         "eventTime": "2013-06-08T14:58:56.591Z",
         "eventTimeZoneOffset": "+02:00",
         "eventID": "ni:///sha-256;cd834b5a08e76778617369c29c9ecc1007508a0ae5dcf063e48b6bf05eb10097?ver=CBV2.0",
-        "certificationInfo": [
-          {
-            "gs1:CertificationDetails": {
-              "gs1:certificationURI": "https://accreditation-council.example.org/certificate/ABC12345"
-            }
-          }
-        ],
+        "certificationInfo": "https://accreditation-council.example.org/certificate/ABC12345",
         "errorDeclaration": {
           "declarationTime": "2013-11-07T14:00:00.000+01:00",
           "reason": "incorrect_data",

--- a/core/src/main/resources/2.0/EPCIS/JSON/Capture/Documents/CurieString_document.json
+++ b/core/src/main/resources/2.0/EPCIS/JSON/Capture/Documents/CurieString_document.json
@@ -14,13 +14,7 @@
         "type": "ObjectEvent",
         "eventTime": "2023-01-11T12:00:00+01:00",
         "eventTimeZoneOffset": "+01:00",
-        "certificationInfo": [
-          {
-            "gs1:CertificationDetails": {
-              "gs1:certificationURI": "https://accreditation-council.example.org/certificate/ABC12345"
-            }
-          }
-        ],
+        "certificationInfo": "https://accreditation-council.example.org/certificate/ABC12345",
         "epcList": [
           "https://id.gs1.de/01/04012345999990/21/XYZ-1234"
         ],

--- a/core/src/main/resources/2.0/EPCIS/JSON/Capture/Documents/Namespaces_at_different_level.json
+++ b/core/src/main/resources/2.0/EPCIS/JSON/Capture/Documents/Namespaces_at_different_level.json
@@ -19,13 +19,7 @@
         ],
         "eventTime": "2023-01-11T12:00:00+01:00",
         "eventTimeZoneOffset": "+01:00",
-        "certificationInfo": [
-          {
-            "gs1:CertificationDetails": {
-              "gs1:certificationURI": "https://accreditation-council.example.org/certificate/ABC12345"
-            }
-          }
-        ],
+        "certificationInfo": "https://accreditation-council.example.org/certificate/ABC12345",
         "epcList": [
           "https://id.gs1.de/01/04012345999990/21/XYZ-1234"
         ],
@@ -63,13 +57,7 @@
         ],
         "eventTime": "2023-01-11T12:00:00+01:00",
         "eventTimeZoneOffset": "+01:00",
-        "certificationInfo": [
-          {
-            "gs1:CertificationDetails": {
-              "gs1:certificationURI": "https://accreditation-council.example.org/certificate/ABC12345"
-            }
-          }
-        ],
+        "certificationInfo": "https://accreditation-council.example.org/certificate/ABC12345",
         "epcList": [
           "https://id.gs1.de/01/04012345999990/21/XYZ-1234"
         ],
@@ -99,13 +87,7 @@
         "type": "ObjectEvent",
         "eventTime": "2023-01-11T12:00:00+01:00",
         "eventTimeZoneOffset": "+01:00",
-        "certificationInfo": [
-          {
-            "gs1:CertificationDetails": {
-              "gs1:certificationURI": "https://accreditation-council.example.org/certificate/ABC12345"
-            }
-          }
-        ],
+        "certificationInfo": "https://accreditation-council.example.org/certificate/ABC12345",
         "epcList": [
           "https://id.gs1.de/01/04012345999990/21/XYZ-1234"
         ],
@@ -135,13 +117,7 @@
         ],
         "eventTime": "2023-01-11T12:00:00+01:00",
         "eventTimeZoneOffset": "+01:00",
-        "certificationInfo": [
-          {
-            "gs1:CertificationDetails": {
-              "gs1:certificationURI": "https://accreditation-council.example.org/certificate/ABC12345"
-            }
-          }
-        ],
+        "certificationInfo": "https://accreditation-council.example.org/certificate/ABC12345",
         "epcList": [
           "https://id.gs1.de/01/04012345999990/21/XYZ-1234"
         ],
@@ -172,13 +148,7 @@
         ],
         "eventTime": "2023-01-11T12:00:00+01:00",
         "eventTimeZoneOffset": "+01:00",
-        "certificationInfo": [
-          {
-            "gs1:CertificationDetails": {
-              "gs1:certificationURI": "https://accreditation-council.example.org/certificate/ABC12345"
-            }
-          }
-        ],
+        "certificationInfo": "https://accreditation-council.example.org/certificate/ABC12345",
         "epcList": [
           "https://id.gs1.de/01/04012345999990/21/XYZ-1234"
         ],

--- a/core/src/main/resources/2.0/EPCIS/JSON/Capture/Documents/ObjectEvent_all_possible_fields.json
+++ b/core/src/main/resources/2.0/EPCIS/JSON/Capture/Documents/ObjectEvent_all_possible_fields.json
@@ -24,13 +24,7 @@
         "eventTime": "2005-04-05T02:33:31.116Z",
         "eventTimeZoneOffset": "-06:00",
         "eventID": "urn:uuid:374d95fc-9457-4a51-bd6a-0bba133845a8",
-        "certificationInfo": [
-          {
-            "gs1:CertificationDetails": {
-              "gs1:certificationURI": "https://accreditation-council.example.org/certificate/ABC12345"
-            }
-          }
-        ],
+        "certificationInfo": "https://accreditation-council.example.org/certificate/ABC12345",
         "errorDeclaration": {
           "declarationTime": "2006-11-07T14:00:00.000+01:00",
           "reason": "incorrect_data",

--- a/core/src/main/resources/2.0/EPCIS/JSON/Capture/Documents/TransactionEvent_all_possible_fields.json
+++ b/core/src/main/resources/2.0/EPCIS/JSON/Capture/Documents/TransactionEvent_all_possible_fields.json
@@ -24,13 +24,7 @@
         "eventTime": "2005-04-04T02:33:31.116Z",
         "eventTimeZoneOffset": "-06:00",
         "eventID": "ni:///sha-256;45a99ca926fdb62b61bb2b29620e1dcdd5b0109613700f7e179881d64d8fabf1?ver=CBV2.0",
-        "certificationInfo": [
-          {
-            "gs1:CertificationDetails": {
-              "gs1:certificationURI": "https://accreditation-council.example.org/certificate/ABC12345"
-            }
-          }
-        ],
+        "certificationInfo": "https://accreditation-council.example.org/certificate/ABC12345",
         "errorDeclaration": {
           "declarationTime": "2006-11-07T14:00:00.000+01:00",
           "reason": "incorrect_data",

--- a/core/src/main/resources/2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_all_possible_fields.json
+++ b/core/src/main/resources/2.0/EPCIS/JSON/Capture/Documents/TransformationEvent_all_possible_fields.json
@@ -27,13 +27,7 @@
         "eventTime": "2013-10-31T14:58:56.591Z",
         "eventTimeZoneOffset": "+02:00",
         "eventID": "ni:///sha-256;0bf4271d60ed65fb687e95f7216c4c0a4c1181c070f657d41385b6fbd93e97ef?ver=CBV2.0",
-        "certificationInfo": [
-          {
-            "gs1:CertificationDetails": {
-              "gs1:certificationURI": "https://accreditation-council.example.org/certificate/ABC12345"
-            }
-          }
-        ],
+        "certificationInfo": "https://accreditation-council.example.org/certificate/ABC12345",
         "errorDeclaration": {
           "declarationTime": "2013-11-07T14:00:00.000+01:00",
           "reason": "incorrect_data",

--- a/core/src/main/resources/2.0/EPCIS/JSON/Query/CurieString_document.json
+++ b/core/src/main/resources/2.0/EPCIS/JSON/Query/CurieString_document.json
@@ -19,13 +19,7 @@
             "type": "ObjectEvent",
             "eventTime": "2023-01-11T12:00:00+01:00",
             "eventTimeZoneOffset": "+01:00",
-            "certificationInfo": [
-              {
-                "gs1:CertificationDetails": {
-                  "gs1:certificationURI": "https://accreditation-council.example.org/certificate/ABC12345"
-                }
-              }
-            ],
+            "certificationInfo": "https://accreditation-council.example.org/certificate/ABC12345",
             "epcList": [
               "https://id.gs1.de/01/04012345999990/21/XYZ-1234"
             ],

--- a/core/src/main/resources/2.0/EPCIS/JSON/Query/ObjectEventWithAllPossibleFields.json
+++ b/core/src/main/resources/2.0/EPCIS/JSON/Query/ObjectEventWithAllPossibleFields.json
@@ -26,13 +26,7 @@
             "eventTime": "2005-04-05T02:33:31.116Z",
             "eventTimeZoneOffset": "-06:00",
             "eventID": "urn:uuid:374d95fc-9457-4a51-bd6a-0bba133845a8",
-            "certificationInfo": [
-              {
-                "gs1:CertificationDetails": {
-                  "gs1:certificationURI": "https://accreditation-council.example.org/certificate/ABC12345"
-                }
-              }
-            ],
+            "certificationInfo": "https://accreditation-council.example.org/certificate/ABC12345",
             "errorDeclaration": {
               "declarationTime": "2006-11-07T14:00:00.000+01:00",
               "reason": "incorrect_data",

--- a/core/src/main/resources/2.0/EPCIS/XML/Capture/Documents/AggregationEvent_all_possible_fields.xml
+++ b/core/src/main/resources/2.0/EPCIS/XML/Capture/Documents/AggregationEvent_all_possible_fields.xml
@@ -4,7 +4,7 @@
     <EPCISBody>
         <EventList>
             <AggregationEvent
-                    xmlns:ext2="http://example.com/ext2/" xmlns:ext1="http://example.com/ext1/" xmlns:ext3="http://example.com/ext3/" xmlns:gs1="https://gs1.org/voc/">
+                    xmlns:ext2="http://example.com/ext2/" xmlns:ext1="http://example.com/ext1/" xmlns:ext3="http://example.com/ext3/">
                 <eventTime>2013-06-08T14:58:56.591Z</eventTime>
                 <eventTimeZoneOffset>+02:00</eventTimeZoneOffset>
                 <eventID>ni:///sha-256;cd834b5a08e76778617369c29c9ecc1007508a0ae5dcf063e48b6bf05eb10097?ver=CBV2.0</eventID>
@@ -15,11 +15,7 @@
                         <correctiveEventID>ni:///sha-256;fec9667280c4710a3fa9558b7bc8ddc2ced0dc442d87f82becae24bb6ca6a46f?ver=CBV2.0</correctiveEventID>
                     </correctiveEventIDs>
                 </errorDeclaration>
-                <certificationInfo>
-                    <gs1:CertificationDetails>
-                        <gs1:certificationURI>https://accreditation-council.example.org/certificate/ABC12345</gs1:certificationURI>
-                    </gs1:CertificationDetails>
-                </certificationInfo>
+                <certificationInfo>https://accreditation-council.example.org/certificate/ABC12345</certificationInfo>
                 <parentID>urn:epc:id:sscc:0614141.1234567890</parentID>
                 <childEPCs>
                     <epc>urn:epc:id:sgtin:0614141.107346.2017</epc>

--- a/core/src/main/resources/2.0/EPCIS/XML/Capture/Documents/CurieString_document.xml
+++ b/core/src/main/resources/2.0/EPCIS/XML/Capture/Documents/CurieString_document.xml
@@ -4,14 +4,10 @@
                      xsi:schemaLocation="urn:epcglobal:epcis:xsd:2 EPCglobal-epcis-2_0.xsd">
     <EPCISBody>
         <EventList>
-            <ObjectEvent xmlns:gs1="https://gs1.org/voc/">
+            <ObjectEvent>
                 <eventTime>2023-01-11T12:00:00+01:00</eventTime>
                 <eventTimeZoneOffset>+01:00</eventTimeZoneOffset>
-                <certificationInfo>
-                    <gs1:CertificationDetails>
-                        <gs1:certificationURI>https://accreditation-council.example.org/certificate/ABC12345</gs1:certificationURI>
-                    </gs1:CertificationDetails>
-                </certificationInfo>
+                <certificationInfo>https://accreditation-council.example.org/certificate/ABC12345</certificationInfo>
                 <epcList>
                     <epc>https://id.gs1.de/01/04012345999990/21/XYZ-1234</epc>
                 </epcList>

--- a/core/src/main/resources/2.0/EPCIS/XML/Capture/Documents/Namespaces_at_different_level.xml
+++ b/core/src/main/resources/2.0/EPCIS/XML/Capture/Documents/Namespaces_at_different_level.xml
@@ -3,14 +3,10 @@
                      creationDate="2023-01-11T12:00:00.000+01:00">
     <EPCISBody>
         <EventList>
-            <ObjectEvent xmlns:ext2="http://www.ext2.net/" xmlns:ext1="https://ns.ext.de/epcis/" xmlns:gs1="https://gs1.org/voc/">
+            <ObjectEvent xmlns:ext2="http://www.ext2.net/" xmlns:ext1="https://ns.ext.de/epcis/">
                 <eventTime>2023-01-11T12:00:00+01:00</eventTime>
                 <eventTimeZoneOffset>+01:00</eventTimeZoneOffset>
-                <certificationInfo>
-                    <gs1:CertificationDetails>
-                        <gs1:certificationURI>https://accreditation-council.example.org/certificate/ABC12345</gs1:certificationURI>
-                    </gs1:CertificationDetails>
-                </certificationInfo>
+                <certificationInfo>https://accreditation-council.example.org/certificate/ABC12345</certificationInfo>
                 <epcList>
                     <epc>https://id.gs1.de/01/04012345999990/21/XYZ-1234</epc>
                 </epcList>
@@ -25,14 +21,10 @@
                 <ext2:address>Cologne</ext2:address>
                 <ext1:name>Testing</ext1:name>
             </ObjectEvent>
-            <ObjectEvent xmlns:ext4="http://www.ext4.net/" xmlns:ext1="https://ns.ext.de/epcis/" xmlns:ext3="http://www.ext3.net/" xmlns:gs1="https://gs1.org/voc/">
+            <ObjectEvent xmlns:ext4="http://www.ext4.net/" xmlns:ext1="https://ns.ext.de/epcis/" xmlns:ext3="http://www.ext3.net/">
                 <eventTime>2023-01-11T12:00:00+01:00</eventTime>
                 <eventTimeZoneOffset>+01:00</eventTimeZoneOffset>
-                <certificationInfo>
-                    <gs1:CertificationDetails>
-                        <gs1:certificationURI>https://accreditation-council.example.org/certificate/ABC12345</gs1:certificationURI>
-                    </gs1:CertificationDetails>
-                </certificationInfo>
+                <certificationInfo>https://accreditation-council.example.org/certificate/ABC12345</certificationInfo>
                 <epcList>
                     <epc>https://id.gs1.de/01/04012345999990/21/XYZ-1234</epc>
                 </epcList>
@@ -50,14 +42,10 @@
                     <ext4:city>Bangalore</ext4:city>
                 </ext4:address>
             </ObjectEvent>
-            <ObjectEvent xmlns:ext1="https://ns.ext.de/epcis/" xmlns:gs1="https://gs1.org/voc/">
+            <ObjectEvent xmlns:ext1="https://ns.ext.de/epcis/">
                 <eventTime>2023-01-11T12:00:00+01:00</eventTime>
                 <eventTimeZoneOffset>+01:00</eventTimeZoneOffset>
-                <certificationInfo>
-                    <gs1:CertificationDetails>
-                        <gs1:certificationURI>https://accreditation-council.example.org/certificate/ABC12345</gs1:certificationURI>
-                    </gs1:CertificationDetails>
-                </certificationInfo>
+                <certificationInfo>https://accreditation-council.example.org/certificate/ABC12345</certificationInfo>
                 <epcList>
                     <epc>https://id.gs1.de/01/04012345999990/21/XYZ-1234</epc>
                 </epcList>
@@ -70,14 +58,10 @@
                     </sensorElement>
                 </sensorElementList>
             </ObjectEvent>
-            <ObjectEvent xmlns:ext5="http://www.ext4.net/" xmlns:ext1="https://ns.ext.de/epcis/" xmlns:gs1="https://gs1.org/voc/">
+            <ObjectEvent xmlns:ext5="http://www.ext4.net/" xmlns:ext1="https://ns.ext.de/epcis/">
                 <eventTime>2023-01-11T12:00:00+01:00</eventTime>
                 <eventTimeZoneOffset>+01:00</eventTimeZoneOffset>
-                <certificationInfo>
-                    <gs1:CertificationDetails>
-                        <gs1:certificationURI>https://accreditation-council.example.org/certificate/ABC12345</gs1:certificationURI>
-                    </gs1:CertificationDetails>
-                </certificationInfo>
+                <certificationInfo>https://accreditation-council.example.org/certificate/ABC12345</certificationInfo>
                 <epcList>
                     <epc>https://id.gs1.de/01/04012345999990/21/XYZ-1234</epc>
                 </epcList>
@@ -91,14 +75,10 @@
                 </sensorElementList>
                 <ext5:hello>Testing</ext5:hello>
             </ObjectEvent>
-            <ObjectEvent xmlns:ext1="https://ns.ext.de/epcis/" xmlns:ext7="http://www.ext7.net/" xmlns:gs1="https://gs1.org/voc/">
+            <ObjectEvent xmlns:ext1="https://ns.ext.de/epcis/" xmlns:ext7="http://www.ext7.net/">
                 <eventTime>2023-01-11T12:00:00+01:00</eventTime>
                 <eventTimeZoneOffset>+01:00</eventTimeZoneOffset>
-                <certificationInfo>
-                    <gs1:CertificationDetails>
-                        <gs1:certificationURI>https://accreditation-council.example.org/certificate/ABC12345</gs1:certificationURI>
-                    </gs1:CertificationDetails>
-                </certificationInfo>
+                <certificationInfo>https://accreditation-council.example.org/certificate/ABC12345</certificationInfo>
                 <epcList>
                     <epc>https://id.gs1.de/01/04012345999990/21/XYZ-1234</epc>
                 </epcList>

--- a/core/src/main/resources/2.0/EPCIS/XML/Capture/Documents/ObjectEvent_all_possible_fields.xml
+++ b/core/src/main/resources/2.0/EPCIS/XML/Capture/Documents/ObjectEvent_all_possible_fields.xml
@@ -2,7 +2,7 @@
 <epcis:EPCISDocument xmlns:epcis="urn:epcglobal:epcis:xsd:2" xmlns:cbvmda="urn:epcglobal:cbv:mda" schemaVersion="2.0" creationDate="2013-06-04T14:59:02.099+02:00">
     <EPCISBody>
         <EventList>
-            <ObjectEvent xmlns:ext2="http://example.com/ext2/" xmlns:ext1="http://example.com/ext1/" xmlns:ext3="http://example.com/ext3/" xmlns:gs1="https://gs1.org/voc/">
+            <ObjectEvent xmlns:ext2="http://example.com/ext2/" xmlns:ext1="http://example.com/ext1/" xmlns:ext3="http://example.com/ext3/">
                 <eventTime>2005-04-05T02:33:31.116Z</eventTime>
                 <eventTimeZoneOffset>-06:00</eventTimeZoneOffset>
                 <eventID>urn:uuid:374d95fc-9457-4a51-bd6a-0bba133845a8</eventID>
@@ -13,11 +13,7 @@
                         <correctiveEventID>ni:///sha-256;fec9667280c4710a3fa9558b7bc8ddc2ced0dc442d87f82becae24bb6ca6a46f?ver=CBV2.0</correctiveEventID>
                     </correctiveEventIDs>
                 </errorDeclaration>
-                <certificationInfo>
-                    <gs1:CertificationDetails>
-                        <gs1:certificationURI>https://accreditation-council.example.org/certificate/ABC12345</gs1:certificationURI>
-                    </gs1:CertificationDetails>
-                </certificationInfo>
+                <certificationInfo>https://accreditation-council.example.org/certificate/ABC12345</certificationInfo>
                 <epcList>
                     <epc>urn:epc:id:sgtin:0614141.107346.2018</epc>
                 </epcList>

--- a/core/src/main/resources/2.0/EPCIS/XML/Capture/Documents/TransactionEvent_all_possible_fields.xml
+++ b/core/src/main/resources/2.0/EPCIS/XML/Capture/Documents/TransactionEvent_all_possible_fields.xml
@@ -2,7 +2,7 @@
 <epcis:EPCISDocument xmlns:epcis="urn:epcglobal:epcis:xsd:2" schemaVersion="2.0" creationDate="2013-06-04T14:59:02.099+02:00">
     <EPCISBody>
         <EventList>
-            <TransactionEvent xmlns:ext2="http://example.com/ext2/" xmlns:ext1="http://example.com/ext1/" xmlns:ext3="http://example.com/ext3/" xmlns:gs1="https://gs1.org/voc/">
+            <TransactionEvent xmlns:ext2="http://example.com/ext2/" xmlns:ext1="http://example.com/ext1/" xmlns:ext3="http://example.com/ext3/">
                 <eventTime>2005-04-04T02:33:31.116Z</eventTime>
                 <eventTimeZoneOffset>-06:00</eventTimeZoneOffset>
                 <eventID>ni:///sha-256;45a99ca926fdb62b61bb2b29620e1dcdd5b0109613700f7e179881d64d8fabf1?ver=CBV2.0</eventID>
@@ -13,11 +13,7 @@
                         <correctiveEventID>ni:///sha-256;fec9667280c4710a3fa9558b7bc8ddc2ced0dc442d87f82becae24bb6ca6a46f?ver=CBV2.0</correctiveEventID>
                     </correctiveEventIDs>
                 </errorDeclaration>
-                <certificationInfo>
-                    <gs1:CertificationDetails>
-                        <gs1:certificationURI>https://accreditation-council.example.org/certificate/ABC12345</gs1:certificationURI>
-                    </gs1:CertificationDetails>
-                </certificationInfo>
+                <certificationInfo>https://accreditation-council.example.org/certificate/ABC12345</certificationInfo>
                 <bizTransactionList>
                     <bizTransaction type="urn:epcglobal:cbv:btt:po">urn:epc:id:gdti:0614141.00001.1618034</bizTransaction>
                     <bizTransaction type="urn:epcglobal:cbv:btt:pedigree">urn:epc:id:gsrn:0614141.0000010253</bizTransaction>

--- a/core/src/main/resources/2.0/EPCIS/XML/Capture/Documents/TransformationEvent_all_possible_fields.xml
+++ b/core/src/main/resources/2.0/EPCIS/XML/Capture/Documents/TransformationEvent_all_possible_fields.xml
@@ -2,7 +2,7 @@
 <epcis:EPCISDocument xmlns:epcis="urn:epcglobal:epcis:xsd:2" schemaVersion="2.0" creationDate="2013-06-04T14:59:02.099+02:00">
     <EPCISBody>
         <EventList>
-            <TransformationEvent xmlns:ext2="http://example.com/ext2/" xmlns:ext1="http://example.com/ext1/" xmlns:ext3="http://example.com/ext3/" xmlns:gs1="https://gs1.org/voc/">
+            <TransformationEvent xmlns:ext2="http://example.com/ext2/" xmlns:ext1="http://example.com/ext1/" xmlns:ext3="http://example.com/ext3/">
                 <eventTime>2013-10-31T14:58:56.591Z</eventTime>
                 <eventTimeZoneOffset>+02:00</eventTimeZoneOffset>
                 <eventID>ni:///sha-256;0bf4271d60ed65fb687e95f7216c4c0a4c1181c070f657d41385b6fbd93e97ef?ver=CBV2.0</eventID>
@@ -13,11 +13,7 @@
                         <correctiveEventID>ni:///sha-256;fec9667280c4710a3fa9558b7bc8ddc2ced0dc442d87f82becae24bb6ca6a46f?ver=CBV2.0</correctiveEventID>
                     </correctiveEventIDs>
                 </errorDeclaration>
-                <certificationInfo>
-                    <gs1:CertificationDetails>
-                        <gs1:certificationURI>https://accreditation-council.example.org/certificate/ABC12345</gs1:certificationURI>
-                    </gs1:CertificationDetails>
-                </certificationInfo>
+                <certificationInfo>https://accreditation-council.example.org/certificate/ABC12345</certificationInfo>
                 <inputEPCList>
                     <epc>urn:epc:id:sgtin:4012345.011122.25</epc>
                     <epc>urn:epc:id:sgtin:4000001.065432.99886655</epc>

--- a/core/src/main/resources/2.0/EPCIS/XML/Query/CurieString_document.xml
+++ b/core/src/main/resources/2.0/EPCIS/XML/Query/CurieString_document.xml
@@ -6,14 +6,10 @@
         <QueryResults>
             <resultsBody>
                 <EventList>
-                    <ObjectEvent xmlns:gs1="https://gs1.org/voc/">
+                    <ObjectEvent>
                         <eventTime>2023-01-11T12:00:00+01:00</eventTime>
                         <eventTimeZoneOffset>+01:00</eventTimeZoneOffset>
-                        <certificationInfo>
-                            <gs1:CertificationDetails>
-                                <gs1:certificationURI>https://accreditation-council.example.org/certificate/ABC12345</gs1:certificationURI>
-                            </gs1:CertificationDetails>
-                        </certificationInfo>
+                        <certificationInfo>https://accreditation-council.example.org/certificate/ABC12345</certificationInfo>
                         <epcList>
                             <epc>https://id.gs1.de/01/04012345999990/21/XYZ-1234</epc>
                         </epcList>

--- a/core/src/main/resources/2.0/EPCIS/XML/Query/ObjectEvent_all_possible_fields.xml
+++ b/core/src/main/resources/2.0/EPCIS/XML/Query/ObjectEvent_all_possible_fields.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<epcisq:EPCISQueryDocument xmlns:epcisq="urn:epcglobal:epcis-query:xsd:2"
+<epcisq:EPCISQueryDocument xmlns:epcisq="urn:epcglobal:epcis-query:xsd:2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cbvmda="urn:epcglobal:cbv:mda:"
                            schemaVersion="2.0" creationDate="2013-06-04T14:59:02.099+02:00">
     <EPCISBody>
         <QueryResults>
             <resultsBody>
                 <EventList>
-                    <ObjectEvent xmlns:ext2="http://example.com/ext2/" xmlns:ext1="http://example.com/ext1/" xmlns:ext3="http://example.com/ext3/" xmlns:gs1="https://gs1.org/voc/">
+                    <ObjectEvent xmlns:ext2="http://example.com/ext2/" xmlns:ext1="http://example.com/ext1/" xmlns:ext3="http://example.com/ext3/">
                         <eventTime>2005-04-05T02:33:31.116Z</eventTime>
                         <eventTimeZoneOffset>-06:00</eventTimeZoneOffset>
                         <eventID>urn:uuid:374d95fc-9457-4a51-bd6a-0bba133845a8</eventID>
@@ -16,11 +16,7 @@
                                 <correctiveEventID>ni:///sha-256;fec9667280c4710a3fa9558b7bc8ddc2ced0dc442d87f82becae24bb6ca6a46f?ver=CBV2.0</correctiveEventID>
                             </correctiveEventIDs>
                         </errorDeclaration>
-                        <certificationInfo>
-                            <gs1:CertificationDetails>
-                                <gs1:certificationURI>https://accreditation-council.example.org/certificate/ABC12345</gs1:certificationURI>
-                            </gs1:CertificationDetails>
-                        </certificationInfo>
+                        <certificationInfo>https://accreditation-council.example.org/certificate/ABC12345</certificationInfo>
                         <epcList>
                             <epc>urn:epc:id:sgtin:0614141.107346.2018</epc>
                         </epcList>


### PR DESCRIPTION
@sboeckelmann 

We recently reverted the changes associated with the `certificationInfo` fields from `List<Object>` to `Object` to accommodate either simple `String` or `List<String>`. Reverting the example EPCIS document changes for the `certificationInfo` in the project to ensure depending modules do not fail the build.

Could you please review the changes and approve the PR?

